### PR TITLE
Update azure-static-web-apps-yellow-mushroom-09a31c910.yml

### DIFF
--- a/.github/workflows/azure-static-web-apps-yellow-mushroom-09a31c910.yml
+++ b/.github/workflows/azure-static-web-apps-yellow-mushroom-09a31c910.yml
@@ -18,6 +18,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18.16.0
+    
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1


### PR DESCRIPTION
added node.js code to force use of node.js 18.16.0